### PR TITLE
Fix type hints, deprecate <3.8 Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,3 @@ re.findall(r'(?:^|[^\w])(!Citrus)\b', string)  # Returns: ['!Citrus']
 ```
 
 This package is designed to allow any pattern to be added to its trie, not just normal words bound by space and punctuation, so that the user can define their own boundaries in the regex, and have the option to leave the data unnormalized when desired.
-
-## Python version comptability
-
-Due to [f-strings](https://www.python.org/dev/peps/pep-0498/) and type hints, this package is only compatible with Python versions >=3.6. 
-
-For Python versions >=2.7, <3.6, backports such as [`future-fstrings`](https://pypi.org/project/future-fstrings/) and [`typing`](https://pypi.org/project/typing/) are available.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author_email='leung.hm@gmail.com',
     url='https://github.com/ermanh/trieregex',
     packages=find_packages(exclude='tests'),
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=[],
     extras_require={
         'testing': ['pytest']
@@ -29,9 +29,10 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     keywords=['regular expressions', 'regex', 'pattern', 'trie'],
     license='MIT',

--- a/trieregex/memoizer.py
+++ b/trieregex/memoizer.py
@@ -1,33 +1,37 @@
-from functools import partial
-from typing import Any, Callable, Dict, Type
+from functools import wraps
+from typing import Any, Callable, Dict, MutableMapping, Protocol, TypeVar
+
+R = TypeVar('R')
+
+class CacheProtocol(Protocol[R]):
+    cache: MutableMapping[str, R]
+
+    def __call__(self, *args: Any, **kwds: Any) -> R:
+        ...
+
+    def clear_cache(self) -> None:
+        ...
 
 
-class Memoizer:
-    """Decorator class for increasing the processing speed of a function using 
+def memoizer() -> Callable[[Callable[..., R]], CacheProtocol[R]]:
+    """Decorator function for increasing the processing speed of a function using 
     memoization with cache-clearing capability
     """
-    __slots__ = ['func', 'cache']
 
-    def __init__(self, func):
-        # type: (Callable) -> None
-        self.func = func
-        self.cache = {}  # type: Dict[str, Any]
+    def decorator(func: Callable[..., R]) -> CacheProtocol[R]:
+        cache: Dict[str, Any] = {}
 
-    def __call__(self, *args):
-        # type: (Any) -> Dict[str, Any]
-        stringed = str(args)
-        if stringed not in self.cache:
-            self.cache[stringed] = self.func(*args)
-        return self.cache[stringed]
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any):
+            stringed = str(args)
+            if stringed not in cache:
+                cache[stringed] = func(*args, **kwargs)
+            return cache[stringed]
 
-    def __get__(self, instance, owner):
-        # type: (object, Type) -> Callable
-        fn = partial(self.__call__, instance)
-        fn.__name__ = f'[Memoizer-decorated function] {self.func.__name__}'
-        fn.__doc__ = f'[Memoizer-decorated function] {self.func.__doc__}'
-        fn.clear_cache = self._clear_cache
-        return fn
+        wrapper.__name__ = f'[Memoizer-decorated function] {func.__name__}'
+        wrapper.__doc__ = f'[Memoizer-decorated function] {func.__doc__}'
+        wrapper.cache = cache  # type: ignore
+        wrapper.clear_cache = lambda: cache.clear()  # type: ignore
+        return wrapper  # type: ignore
 
-    def _clear_cache(self):
-        # type: () -> None
-        self.cache.clear()
+    return decorator


### PR DESCRIPTION
This is a rather opinionated PR, killing off Python 3.7 compatibility _and below_ due to the `Protocol` type.

I did this instead of adding `typing_extensions` to the requirements since 3.6 is EOL and 3.7 is cutting it close anyways.

This repo seems dead but if the owner ever sees this, I'm willing to rework this PR as they see fit if it's going to be merged.